### PR TITLE
Implement basic Claims versioning through constants.

### DIFF
--- a/lib/tokie/abstract_base.rb
+++ b/lib/tokie/abstract_base.rb
@@ -17,7 +17,7 @@ module Tokie
 
     private
       def header
-        { 'typ' => 'JWT', 'alg' => @digest.to_s }
+        { 'typ' => 'JWT', 'alg' => @digest.to_s, 'ver' => @claims.version }
       end
 
       def encoded_header

--- a/lib/tokie/claims.rb
+++ b/lib/tokie/claims.rb
@@ -4,61 +4,77 @@ module Tokie
   class InvalidClaims < StandardError; end
   class ExpiredClaims < StandardError; end
 
-  class Claims
-    attr_reader :payload, :purpose, :expires_at
+  module Claims
+    extend self
 
-    def initialize(payload, options = {})
-      @payload = payload
-      @purpose = self.class.pick_purpose(options)
-      @expires_at = pick_expiration(options)
+    def method_missing(meth, *args, &block)
+      version(latest_version).send(meth, *args, &block)
     end
 
-    class << self
-      attr_accessor :expires_in
+    def latest_version
+      :V1
+    end
 
-      def parse(claims, options = {})
-        if verify!(claims, options)
-          new claims['pld'], expires_at: claims['exp'], for: claims['for']
+    def version(version)
+      const_get version || latest_version
+    end
+
+    class V1
+      attr_reader :payload, :purpose, :expires_at
+
+      def initialize(payload, options = {})
+        @payload = payload
+        @purpose = self.class.pick_purpose(options)
+        @expires_at = pick_expiration(options)
+      end
+
+      class << self
+        attr_accessor :expires_in
+
+        def parse(claims, options = {})
+          if verify!(claims, options)
+            new claims['pld'], expires_at: claims['exp'], for: claims['for']
+          end
+        end
+
+        def verify!(claims, options)
+          raise InvalidClaims if claims['for'] != pick_purpose(options)
+
+          claims['pld'] if parse_expiration(claims['exp'])
+        end
+
+        def pick_purpose(options)
+          options.fetch(:for) { 'universal' }
+        end
+
+        private
+          def parse_expiration(expiration)
+            return true unless expiration
+
+            Time.iso8601(expiration).tap do |timestamp|
+              raise ExpiredClaims if Time.now.utc > timestamp
+            end
+          end
+      end
+
+      def to_h
+        { 'pld' => @payload, 'for' => @purpose.to_s }.tap do |claims|
+          claims['exp'] = @expires_at.utc.iso8601(3) if @expires_at
         end
       end
 
-      def verify!(claims, options)
-        raise InvalidClaims if claims['for'] != pick_purpose(options)
-
-        claims['pld'] if parse_expiration(claims['exp'])
-      end
-
-      def pick_purpose(options)
-        options.fetch(:for) { 'universal' }
+      def ==(other)
+        other.is_a?(self.class) && @purpose == other.purpose && @payload == other.payload
       end
 
       private
-        def parse_expiration(expiration)
-          return true unless expiration
+        def pick_expiration(options)
+          return options[:expires_at] if options.key?(:expires_at)
 
-          Time.iso8601(expiration).tap do |timestamp|
-            raise ExpiredClaims if Time.now.utc > timestamp
+          if expires_in = options.fetch(:expires_in) { self.class.expires_in }
+            expires_in.from_now
           end
         end
     end
-
-    def to_h
-      { 'pld' => @payload, 'for' => @purpose.to_s }.tap do |claims|
-        claims['exp'] = @expires_at.utc.iso8601(3) if @expires_at
-      end
-    end
-
-    def ==(other)
-      other.is_a?(self.class) && @purpose == other.purpose && @payload == other.payload
-    end
-
-    private
-      def pick_expiration(options)
-        return options[:expires_at] if options.key?(:expires_at)
-
-        if expires_in = options.fetch(:expires_in) { self.class.expires_in }
-          expires_in.from_now
-        end
-      end
   end
 end

--- a/lib/tokie/claims.rb
+++ b/lib/tokie/claims.rb
@@ -8,14 +8,14 @@ module Tokie
     extend self
 
     def method_missing(meth, *args, &block)
-      version(latest_version).send(meth, *args, &block)
+      version.send(meth, *args, &block)
     end
 
     def latest_version
       :V1
     end
 
-    def version(version)
+    def version(version = nil)
       const_get version || latest_version
     rescue NameError
       raise ArgumentError, "unknown version: #{version}"
@@ -39,7 +39,7 @@ module Tokie
           end
         end
 
-        def verify!(claims, options)
+        def verify!(claims, options = {})
           raise InvalidClaims if claims['for'] != pick_purpose(options)
 
           claims['pld'] if parse_expiration(claims['exp'])
@@ -47,6 +47,10 @@ module Tokie
 
         def pick_purpose(options)
           options.fetch(:for) { 'universal' }
+        end
+
+        def version
+          name.split('::').last
         end
 
         private
@@ -57,6 +61,10 @@ module Tokie
               raise ExpiredClaims if Time.now.utc > timestamp
             end
           end
+      end
+
+      def version
+        self.class.version
       end
 
       def to_h

--- a/lib/tokie/claims.rb
+++ b/lib/tokie/claims.rb
@@ -17,6 +17,8 @@ module Tokie
 
     def version(version)
       const_get version || latest_version
+    rescue NameError
+      raise ArgumentError, "unknown version: #{version}"
     end
 
     class V1

--- a/lib/tokie/token_generator.rb
+++ b/lib/tokie/token_generator.rb
@@ -3,8 +3,7 @@ module Tokie
   class InvalidMessage < StandardError; end
 
   class TokenGenerator
-    def initialize(version: Claims.latest_version, **options)
-      @version = version
+    def initialize(options = {})
       @generator_options = options
     end
 
@@ -20,7 +19,7 @@ module Tokie
 
     def verify(data, options = {})
       if claims = Signer.new(data, @generator_options).verify
-        Claims.version(@version).verify!(claims, options)
+        Claims.verify!(claims, options)
       end
     end
 
@@ -40,7 +39,7 @@ module Tokie
 
     def decrypt(data, options = {})
       if claims = Encryptor.new(data, @generator_options).decrypt
-        Claims.version(@version).verify!(claims, options)
+        Claims.verify!(claims, options)
       end
     end
 

--- a/lib/tokie/token_generator.rb
+++ b/lib/tokie/token_generator.rb
@@ -3,7 +3,8 @@ module Tokie
   class InvalidMessage < StandardError; end
 
   class TokenGenerator
-    def initialize(options = {})
+    def initialize(version: Claims.latest_version, **options)
+      @version = version
       @generator_options = options
     end
 
@@ -19,7 +20,7 @@ module Tokie
 
     def verify(data, options = {})
       if claims = Signer.new(data, @generator_options).verify
-        Claims.verify!(claims, options)
+        Claims.version(@version).verify!(claims, options)
       end
     end
 
@@ -39,7 +40,7 @@ module Tokie
 
     def decrypt(data, options = {})
       if claims = Encryptor.new(data, @generator_options).decrypt
-        Claims.verify!(claims, options)
+        Claims.version(@version).verify!(claims, options)
       end
     end
 

--- a/test/claims_test.rb
+++ b/test/claims_test.rb
@@ -144,7 +144,7 @@ class ClaimsVersioningTest < ActiveSupport::TestCase
   end
 
   test "fetching non existent version" do
-    assert_raise NameError do
+    assert_raise ArgumentError do
       Tokie::Claims.version(:UninitializedConstant)
     end
   end

--- a/test/claims_test.rb
+++ b/test/claims_test.rb
@@ -149,17 +149,11 @@ class ClaimsVersioningTest < ActiveSupport::TestCase
     end
   end
 
-  test "versioning" do
-    class Tokie::Claims::V200
-      def self.verify!(data, options = {})
-        '2.0: Much faster! Very lazy!'
-      end
-    end
+  test "verify! dispatches to version class" do
+    assert Tokie::Claims.verify! 'pld' => 'hello', 'for' => 'universal'
+  end
 
-    assert_equal Tokie::Claims::V200, Tokie::Claims.version(:V200)
-
-    Tokie::Claims.stub(:latest_version, :V200) do
-      assert_equal '2.0: Much faster! Very lazy!', Tokie::Claims.verify!('something')
-    end
+  test "version" do
+    assert_equal 'V1', Tokie::Claims::V1.version
   end
 end


### PR DESCRIPTION
Let's make it easy to rev' our metadata in the future.

The versions are scoped to a class like V1, V2 etc. Introducing a new version requires adding a new class and updating the `latest_version` method.

The version still needs to be encoded in the header. I vote for a 'ver' key that stores a string, like this: `{ 'ver' => 'V1' }`. c/d?

Passing in the version to `TokenGenerator` probably isn't the way to go, but right now extracting the version from the header feels cumbersome. How can we make that easier or is there another way I'm missing?

I'm unsure if we should use `method_missing` here, but it does work :grin:

cc @jeremy @chancancode @rafaelfranca
